### PR TITLE
Change github auth method of custom action for `furiosa-smi` preparation

### DIFF
--- a/.github/workflows/build-and-test-golang-project.yml
+++ b/.github/workflows/build-and-test-golang-project.yml
@@ -18,39 +18,10 @@ jobs:
         go-version: [ '1.23.2' ]
 
     steps:
-      - name: Checkout `furiosa-smi`
-        id: furiosa-smi-checkout
-        uses: actions/checkout@v4
+      - name: Prepare `furiosa-smi`
+        uses: furiosa-ai/furiosa-smi/actions/prepare@add-ssh-key-input-into-the-prepare-furiosa-smi-action
         with:
-          repository: furiosa-ai/furiosa-smi
-          token: '${{ secrets.TOKEN_FOR_CLONE_ANOTHER_REPO }}'
-          path: furiosa-smi
-      - name: Create `furiosa-smi` dependencies related directories
-        shell: bash
-        run: |
-          sudo mkdir -p /usr/local/lib
-          sudo mkdir -p /usr/local/include/furiosa
-          sudo chown -R $(id -u -n):$(id -g -n) /usr/local/lib
-          sudo chown -R $(id -u -n):$(id -g -n) /usr/local/include/furiosa
-      - name: Cache & Restore `furiosa-smi` build results
-        id: cache-furiosa-smi
-        uses: actions/cache@v4
-        with:
-          key: 'furiosa-smi-${{ steps.furiosa-smi-checkout.outputs.commit }}'
-          path: |
-            /usr/local/lib/libfuriosa_smi.so
-            /usr/local/include/furiosa/furiosa_smi.h
-      - name: Build & Install `furiosa-smi`
-        if: steps.cache-furiosa-smi.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          cd furiosa-smi
-          cargo build
-          make install
-      - name: Run `sudo ldconfig`
-        shell: bash
-        run: |
-          sudo ldconfig
+          ssh-key: ${{ secrets.FURIOSA_SMI_RDONLY_DEPLOY_KEY }}
 
       - uses: actions/checkout@v4
       - name: Setup Go ${{ matrix.go-version }}


### PR DESCRIPTION
### One line PR Description
- resolve: furiosa-ai/cloud-native-toolkit#8

Use SSH Key authentiation rather than using PAT

### What type of PR is this?
/kind devops

### Special notes for reviewer
- Auth method has been change from PAT to SSH Key due to [this Slack thread](https://furiosa-ai.slack.com/archives/C06DMGWTULF/p1736920528433969?thread_ts=1733794668.408729&cid=C06DMGWTULF).