### PR TITLE
support String method in bdf format for pcieRootComplex and pcieSwitch API

### DIFF
--- a/example/device_lister/device_lister.go
+++ b/example/device_lister/device_lister.go
@@ -183,13 +183,13 @@ func main() {
 
 		pcieRootComplexInfo := pcieInfo.RootComplexInfo()
 		fmt.Printf("PCIe Root Complex Info\n")
-		fmt.Printf("  Device root complex: %04x:%02x\n", pcieRootComplexInfo.Domain(), pcieRootComplexInfo.Bus())
+		fmt.Printf("  Device root complex: %s\n", pcieRootComplexInfo.String())
 
 		pcieSwitchInfo := pcieInfo.SwitchInfo()
 		if pcieSwitchInfo == nil {
 			fmt.Printf("  Device pcie switch: Not available\n")
 		} else {
-			fmt.Printf("  Device pcie switch: %04x:%02x:%02x:%01x\n", pcieSwitchInfo.Domain(), pcieSwitchInfo.Bus(), pcieSwitchInfo.Device(), pcieSwitchInfo.Function())
+			fmt.Printf("  Device pcie switch: %s\n", pcieSwitchInfo.String())
 		}
 	}
 }

--- a/pkg/smi/mock_common.go
+++ b/pkg/smi/mock_common.go
@@ -351,6 +351,10 @@ func (s *staticMockPcieRootComplexInfo) Bus() uint8 {
 	return 0x42
 }
 
+func (s *staticMockPcieRootComplexInfo) String() string {
+	return fmt.Sprintf("%04x:%02x", s.Domain(), s.Bus())
+}
+
 type staticMockPcieSwitchInfo struct{}
 
 var _ PcieSwitchInfo = new(staticMockPcieSwitchInfo)
@@ -369,4 +373,8 @@ func (s *staticMockPcieSwitchInfo) Device() uint8 {
 
 func (s *staticMockPcieSwitchInfo) Function() uint8 {
 	return 0x00
+}
+
+func (s *staticMockPcieSwitchInfo) String() string {
+	return fmt.Sprintf("%04x:%02x:%02x.%x", s.Domain(), s.Bus(), s.Device(), s.Function())
 }

--- a/pkg/smi/mock_common.go
+++ b/pkg/smi/mock_common.go
@@ -376,5 +376,5 @@ func (s *staticMockPcieSwitchInfo) Function() uint8 {
 }
 
 func (s *staticMockPcieSwitchInfo) String() string {
-	return fmt.Sprintf("%04x:%02x:%02x.%x", s.Domain(), s.Bus(), s.Device(), s.Function())
+	return fmt.Sprintf("%04x:%02x:%02x.%d", s.Domain(), s.Bus(), s.Device(), s.Function())
 }

--- a/pkg/smi/pcie_info.go
+++ b/pkg/smi/pcie_info.go
@@ -1,6 +1,7 @@
 package smi
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/furiosa-ai/furiosa-smi-go/pkg/smi/binding"
@@ -194,6 +195,8 @@ type PcieRootComplexInfo interface {
 	Domain() uint16
 	// Bus returns bus information.
 	Bus() uint8
+	// String returns a string representation of the PCIe root complex information in BDF format.
+	String() string
 }
 
 var _ PcieRootComplexInfo = new(pcieRootComplexInfo)
@@ -216,6 +219,10 @@ func (p *pcieRootComplexInfo) Bus() uint8 {
 	return p.raw.Bus
 }
 
+func (p *pcieRootComplexInfo) String() string {
+	return fmt.Sprintf("%04x:%02x", p.Domain(), p.Bus())
+}
+
 type PcieSwitchInfo interface {
 	// Domain returns domain information.
 	Domain() uint16
@@ -225,6 +232,8 @@ type PcieSwitchInfo interface {
 	Device() uint8
 	// Function returns function information.
 	Function() uint8
+	// String returns a string representation of the PCIe switch information in BDF format.
+	String() string
 }
 
 var _ PcieSwitchInfo = new(pcieSwitchInfo)
@@ -257,4 +266,13 @@ func (p *pcieSwitchInfo) Device() uint8 {
 
 func (p *pcieSwitchInfo) Function() uint8 {
 	return p.raw.Function
+}
+
+func (p *pcieSwitchInfo) String() string {
+	return fmt.Sprintf("%04x:%02x:%02x.%d",
+		p.Domain(),
+		p.Bus(),
+		p.Device(),
+		p.Function(),
+	)
 }


### PR DESCRIPTION
### One line PR Description
[//]: # (If this PR references other issue, please paste that link into below `{ISSUE_LINK_HERE}` section and uncomment it.)
[//]: # (- resolve: {ISSUE_LINK_HERE})
- add string methods for PcieSwitchInfo and PcieRootComplexInfo

### What type of PR is this?
[//]: # (Please add same label in your PR too.)

<!--
/kind bug
/kind cleanup
/kind feature
/kind chore
/kind devops
/kind documentation
-->

### Special notes for reviewer
